### PR TITLE
Add Flask app using Spleeter for stem extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Song Processor
+
+This is a simple Flask application that uploads a song and separates vocals and accompaniment using **Spleeter**.
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   python app.py
+   ```
+3. Open the browser at `http://localhost:5000` and upload a track.
+
+Separated stems will be stored inside `static/stems` and can be played or downloaded from the page.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,39 @@
+from flask import Flask, render_template, request, redirect, url_for
+import os
+from werkzeug.utils import secure_filename
+from spleeter.separator import Separator
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = 'uploads'
+app.config['STEMS_FOLDER'] = 'static/stems'
+
+separator = Separator('spleeter:2stems')
+
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+os.makedirs(app.config['STEMS_FOLDER'], exist_ok=True)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        if 'audio' not in request.files:
+            return redirect(request.url)
+        file = request.files['audio']
+        if file.filename == '':
+            return redirect(request.url)
+        filename = secure_filename(file.filename)
+        upload_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(upload_path)
+
+        stems_dir = os.path.join(app.config['STEMS_FOLDER'], os.path.splitext(filename)[0])
+        os.makedirs(stems_dir, exist_ok=True)
+        separator.separate_to_file(upload_path, stems_dir)
+
+        stems = []
+        for stem_file in os.listdir(stems_dir):
+            stems.append(url_for('static', filename=f"stems/{os.path.splitext(filename)[0]}/{stem_file}"))
+        return render_template('index.html', stems=stems)
+
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+spleeter

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data" class="mb-4">
+    <div class="input-group">
+        <input type="file" name="audio" accept="audio/*" class="form-control" required>
+        <button class="btn btn-primary" type="submit">Upload</button>
+    </div>
+</form>
+{% if stems %}
+<div class="row">
+    {% for stem in stems %}
+    <div class="col-md-6 mb-3">
+        <div class="card">
+            <audio controls class="w-100">
+                <source src="{{ stem }}" type="audio/wav">
+            </audio>
+            <div class="card-body">
+                <a href="{{ stem }}" download class="btn btn-success">Download</a>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Song Processor</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h1 class="mb-4">Song Processor</h1>
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a simple Flask server that uses Spleeter to separate vocals and accompaniment
- add upload form template with Bootstrap styling
- add requirements file and placeholder static directory
- document setup steps

## Testing
- `pip install -r requirements.txt` *(fails: error building numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6847488d91bc832f9f3ef1af0db203b4